### PR TITLE
Fix formating of crlnumber

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
   "name": "m0dular-crl_truncate",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Adrian Parreiras Horta",
   "summary": "Truncate the CRL issued by the Puppet CA",
-  "license": "GPLv3",
+  "license": "GPL-3.0-or-later",
   "source": "https://github.com/m0dular/crl_truncate",
   "project_page": "https://github.com/m0dular/crl_truncate",
   "dependencies": [

--- a/tasks/crl_truncate.sh
+++ b/tasks/crl_truncate.sh
@@ -125,8 +125,10 @@ fi
 # openssl requires that the crlnumber be hex with an even number of digits
 # %02 in the format string with pad it to two characters, otherwise we have to check for evenness and add a 0 if needed
 crl_number="$("$PUPPET_BIN"/openssl crl -crlnumber -noout -in "$ssldir"/ca/ca_crl.pem)"
-crl_number="$(printf '%02x\n' "0x${crl_number##*=}")"
+# Strip everything before the '=' character and increment by one, as the docs say this should be the next crl number
+crl_number="$(printf '%02x\n' $((0x${crl_number##*=} +1 )))"
 
+# Add a leading 0 if we have an odd number of digits
 (( ${#crl_number} % 2 == 0 )) || crl_number="0${crl_number}"
 echo "$crl_number" >/tmp/crlnumber
 

--- a/tasks/crl_truncate.sh
+++ b/tasks/crl_truncate.sh
@@ -122,8 +122,13 @@ fi
 # Create an empty index
 >/tmp/index.txt
 
+# openssl requires that the crlnumber be hex with an even number of digits
+# %02 in the format string with pad it to two characters, otherwise we have to check for evenness and add a 0 if needed
 crl_number="$("$PUPPET_BIN"/openssl crl -crlnumber -noout -in "$ssldir"/ca/ca_crl.pem)"
-printf '%02d\n' "${crl_number##*=}" >/tmp/crlnumber
+crl_number="$(printf '%02x\n' "0x${crl_number##*=}")"
+
+(( ${#crl_number} % 2 == 0 )) || crl_number="0${crl_number}"
+echo "$crl_number" >/tmp/crlnumber
 
 "$PUPPET_BIN"/openssl ca -config /tmp/openssl.cnf -gencrl -out /tmp/intermediate_crl.pem
 


### PR DESCRIPTION
Prior to this commit, the printf that wrote the crlnumber to disk would
fail it if couldn't be parsed as decimal.  This commit ensures the
number is a hex with an even number of digits